### PR TITLE
Use `subject` endpoint for Lobid API sample

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -31,7 +31,7 @@ function myController($scope, OpenSearchSuggestions) {
             jsonp: 'jsonp'
         },
         {
-            url: "http://api.lobid.org/person?format=short&name=",
+            url: "http://api.lobid.org/subject?format=short&name=",
             transform: function(r,q) {
                 return {
                     query: q,


### PR DESCRIPTION
The UI says the Lobid API is used for GND subjects, 
but the code uses the `/person` API endpoint. Compare:

http://api.lobid.org/person?format=short&name=Tr%C3%BCmmer
http://api.lobid.org/subject?format=short&name=Tr%C3%BCmmer
